### PR TITLE
Fix inability to build jar

### DIFF
--- a/mc1122/build.gradle
+++ b/mc1122/build.gradle
@@ -131,7 +131,7 @@ jar {
 }
 
 shadowJar {
-    archiveClassifier.set("shadow")
+    archiveClassifier.set("")
     compileJava.options.encoding = "UTF-8"
     exclude "native-binaries/*"
 


### PR DESCRIPTION
This PR fixes `./gradlew build` failing with the following error:
```
A problem was found with the configuration of task ':mc1122:reobfJar' (type 'RenameJarInPlace').
  - In plugin 'net.minecraftforge.gradle' type 'net.minecraftforge.gradle.userdev.tasks.RenameJarInPlace' property 'input' specifies file '/home/tudbut/gitshit/ViaForge/mc1122/build/libs/viaforge-1.12.2-2.0.0.jar' which doesn't exist.
```